### PR TITLE
feat: add an option to support custom 404 pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ The Caddyfile directive would look something like this:
 		bucket <bucket_name>
 		region <region_name>
 		index  <list of index file names>
-                endpoint <alternative S3 endpoint>
+		endpoint <alternative S3 endpoint>
 		root   <key prefix>
 		enable_put
 		enable_delete
+		not_found_key <S3 key>
 	}
 ```
 
@@ -44,6 +45,7 @@ The Caddyfile directive would look something like this:
 | root                | string   | no  |    | Set a "prefix" to be added to key |
 | enable_put          | bool     | yes | false   | Allow PUT method to be sent through proxy |
 | enable_delete       | bool     | yes | false   | Allow DELETE method to be sent through proxy |
+| not_found_key       | string   | no |  | S3 key that points to a custom 404 page |
 
 ## Credentials
 

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -14,14 +14,15 @@ func init() {
 // requests to S3 and configures it with this syntax:
 //
 //    s3proxy [<matcher>] {
-//            root   <path to prefix S3 key with>
-//	      region <aws region>
-//	      bucket <s3 bucket name>
-//	      index  <files...>
-//	      hide   <file patterns...>
-//	      endpoint: <alternative endpoint>
-//            enable_put
-//            enable_delete
+//        root   <path to prefix S3 key with>
+//        region <aws region>
+//        bucket <s3 bucket name>
+//        index  <files...>
+//        hide   <file patterns...>
+//        endpoint: <alternative endpoint>
+//        not_found_key <S3 key to a 404 page>
+//        enable_put
+//        enable_delete
 //    }
 //
 func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error) {
@@ -68,6 +69,10 @@ parseLoop:
 			b.EnablePut = true
 		case "enable_delete":
 			b.EnableDelete = true
+		case "not_found_key":
+			if !h.AllArgs(&b.NotFoundKey) {
+				return nil, h.ArgErr()
+			}
 		default:
 			return nil, h.Errf("%s not a valid s3proxy option", h.Val())
 		}

--- a/caddyfile_test.go
+++ b/caddyfile_test.go
@@ -111,6 +111,18 @@ func TestParseCaddyfile(t *testing.T) {
 				EnableDelete: true,
 			},
 		},
+		testCase{
+			desc: "enable not_found_key",
+			input: `s3proxy {
+				bucket mybucket
+				not_found_key "path/to/404.html"
+			}`,
+			shouldErr: false,
+			obj: S3Proxy{
+				Bucket:      "mybucket",
+				NotFoundKey: "path/to/404.html",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/s3proxy.go
+++ b/s3proxy.go
@@ -61,6 +61,11 @@ type S3Proxy struct {
 	// Flag to determine if DELETE operations are allowed (default false)
 	EnableDelete bool
 
+	// Key that should exist in the bucket and that the proxy will fallback to
+	// if the requested path doesn't exist in the bucket. This is especially
+	// useful to make custom 404 error pages.
+	NotFoundKey string `json:"not_found_key,omitempty"`
+
 	client *s3.S3
 	log    *zap.Logger
 }
@@ -228,6 +233,48 @@ func (p S3Proxy) HandleDelete(w http.ResponseWriter, r *http.Request, key string
 
 	return nil
 }
+
+func (p S3Proxy) writeResponseFromGetObject(w http.ResponseWriter, obj *s3.GetObjectOutput) error {
+	// Copy headers from AWS response to our response
+	setStrHeader(w, "Content-Disposition", obj.ContentDisposition)
+	setStrHeader(w, "Content-Encoding", obj.ContentEncoding)
+	setStrHeader(w, "Content-Language", obj.ContentLanguage)
+	setStrHeader(w, "Content-Range", obj.ContentRange)
+	setStrHeader(w, "Content-Type", obj.ContentType)
+	setStrHeader(w, "ETag", obj.ETag)
+	setTimeHeader(w, "Last-Modified", obj.LastModified)
+
+	var err error
+	if obj.Body != nil {
+		// io.Copy will set Content-Length
+		w.Header().Del("Content-Length")
+		_, err = io.Copy(w, obj.Body)
+	}
+
+	return err
+}
+
+func (p S3Proxy) serve404(w http.ResponseWriter, parentError error) error {
+	notFoundKey := p.NotFoundKey
+
+	w.WriteHeader(http.StatusNotFound)
+
+	if notFoundKey == "" {
+		return caddyhttp.Error(http.StatusNotFound, parentError)
+	}
+
+	obj, err := p.getS3Object(p.Bucket, notFoundKey, nil)
+	if err != nil {
+		return caddyhttp.Error(http.StatusNotFound, err)
+	}
+
+	if err := p.writeResponseFromGetObject(w, obj); err != nil {
+		return caddyhttp.Error(http.StatusNotFound, err)
+	}
+
+	return caddyhttp.Error(http.StatusNotFound, parentError)
+}
+
 func (p S3Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 
@@ -235,7 +282,7 @@ func (p S3Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhtt
 
 	// If file is hidden - return 404
 	if fileHidden(fullPath, p.Hide) {
-		return caddyhttp.Error(http.StatusNotFound, nil)
+		return p.serve404(w, nil)
 	}
 
 	switch r.Method {
@@ -289,7 +336,7 @@ func (p S3Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhtt
 					zap.String("key", fullPath),
 					zap.String("err", aerr.Error()),
 				)
-				return caddyhttp.Error(http.StatusNotFound, aerr)
+				return p.serve404(w, aerr)
 			default:
 				if code, ok := awsErrorCodesMapping[aerr.Code()]; ok {
 					return caddyhttp.Error(code, nil)
@@ -313,24 +360,7 @@ func (p S3Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhtt
 		}
 	}
 
-	// Copy headers from AWS response to our response
-	setStrHeader(w, "Content-Disposition", obj.ContentDisposition)
-	setStrHeader(w, "Content-Encoding", obj.ContentEncoding)
-	setStrHeader(w, "Content-Language", obj.ContentLanguage)
-	setStrHeader(w, "Content-Range", obj.ContentRange)
-	setStrHeader(w, "Content-Type", obj.ContentType)
-	setStrHeader(w, "ETag", obj.ETag)
-	setTimeHeader(w, "Last-Modified", obj.LastModified)
-
-	if obj.Body != nil {
-		// io.Copy will set Content-Length
-		w.Header().Del("Content-Length")
-		if _, err := io.Copy(w, obj.Body); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return p.writeResponseFromGetObject(w, obj)
 }
 
 func setStrHeader(w http.ResponseWriter, key string, value *string) {


### PR DESCRIPTION
Thanks for sharing this useful caddy module. I made this tiny feature that allows fallback to another key from the bucket in case the target object doesn't exist. I used to do this with very exotic nginx conf for static website hosting :yum: . Let me know what you think.