### PR TITLE
Adds additional logging when index is missing

### DIFF
--- a/s3proxy.go
+++ b/s3proxy.go
@@ -419,6 +419,15 @@ func (p S3Proxy) GetHandler(w http.ResponseWriter, r *http.Request, fullPath str
 		for _, indexPage := range p.IndexNames {
 			indexPath := path.Join(fullPath, indexPage)
 			obj, err = p.getS3Object(p.Bucket, indexPath, r.Header)
+
+			if err != nil {
+				p.log.Warn("failed to get object",
+					zap.String("bucket", p.Bucket),
+					zap.String("key", fullPath),
+					zap.String("err", err.Error()),
+				)
+			}
+
 			if err == nil {
 				// We found an index!
 				isDir = false


### PR DESCRIPTION
Relates to https://github.com/lindenlab/caddy-s3-proxy/issues/27#issuecomment-727918360. 

This adds additional logging if a specified indexName failed to fetch.
In my case I had to debug a little bit further until I found out that I had an permission issue on `GET /`.