### PR TITLE
Moved "get from s3" log level from INFO to DEBUG

### DIFF
--- a/s3proxy.go
+++ b/s3proxy.go
@@ -187,7 +187,7 @@ func (p S3Proxy) getS3Object(bucket string, path string, headers http.Header) (*
 		}
 	}
 
-	p.log.Info("get from S3",
+	p.log.Debug("get from S3",
 		zap.String("bucket", bucket),
 		zap.String("key", path),
 	)


### PR DESCRIPTION
In my personal opinion this could be a DEBUG information as this is pretty spammy.
In combination with #31 you'll get all relevant information if there is an issue.

What do you think about this? 