### PR TITLE
Add more headers to the response

### DIFF
--- a/s3proxy.go
+++ b/s3proxy.go
@@ -301,12 +301,14 @@ func (p S3Proxy) BrowseHandler(w http.ResponseWriter, r *http.Request, key strin
 
 func (p S3Proxy) writeResponseFromGetObject(w http.ResponseWriter, obj *s3.GetObjectOutput) error {
 	// Copy headers from AWS response to our response
+	setStrHeader(w, "Cache-Control", obj.CacheControl)
 	setStrHeader(w, "Content-Disposition", obj.ContentDisposition)
 	setStrHeader(w, "Content-Encoding", obj.ContentEncoding)
 	setStrHeader(w, "Content-Language", obj.ContentLanguage)
 	setStrHeader(w, "Content-Range", obj.ContentRange)
 	setStrHeader(w, "Content-Type", obj.ContentType)
 	setStrHeader(w, "ETag", obj.ETag)
+	setStrHeader(w, "Expires", obj.Expires)
 	setTimeHeader(w, "Last-Modified", obj.LastModified)
 
 	var err error

--- a/s3proxy.go
+++ b/s3proxy.go
@@ -311,6 +311,11 @@ func (p S3Proxy) writeResponseFromGetObject(w http.ResponseWriter, obj *s3.GetOb
 	setStrHeader(w, "Expires", obj.Expires)
 	setTimeHeader(w, "Last-Modified", obj.LastModified)
 
+	// Adds all custom headers which where used on this object
+	for key, value := range obj.Metadata {
+		setStrHeader(w, key, value)
+	}
+
 	var err error
 	if obj.Body != nil {
 		// io.Copy will set Content-Length


### PR DESCRIPTION
This addresses #33. For now it's missing it's missing the custom map to "allow" or "deny" specific headers. 

Dunno if this is required for now. In my case I'm fine with this situation. 