### PR TITLE
Fix for issue #53

### DIFF
--- a/browse.go
+++ b/browse.go
@@ -54,9 +54,8 @@ func (po PageObj) GenerateJson(w http.ResponseWriter) error {
 }
 
 func (p S3Proxy) ConstructListObjInput(r *http.Request, key string) s3.ListObjectsV2Input {
-	// We should only get here if the path ends in a /, however, when we make the
-	//call to ListObjects no / should be there
-	prefix := strings.TrimSuffix(key, "/")
+	// We need to strip the first '/' from the key to make it a valid prefix
+	prefix := strings.TrimPrefix(key, "/")
 
 	input := s3.ListObjectsV2Input{
 		Bucket:    aws.String(p.Bucket),

--- a/browse_test.go
+++ b/browse_test.go
@@ -28,7 +28,7 @@ func TestConstructListObjInput(t *testing.T) {
 			expected: s3.ListObjectsV2Input{
 				Bucket:    aws.String("myBucket"),
 				Delimiter: aws.String("/"),
-				Prefix:    aws.String("/mypath"),
+				Prefix:    aws.String("mypath/"),
 			},
 		},
 		testCase{
@@ -39,7 +39,7 @@ func TestConstructListObjInput(t *testing.T) {
 			expected: s3.ListObjectsV2Input{
 				Bucket:    aws.String("myBucket"),
 				Delimiter: aws.String("/"),
-				Prefix:    aws.String("/mypath"),
+				Prefix:    aws.String("mypath/"),
 				MaxKeys:   aws.Int64(20),
 			},
 		},
@@ -51,7 +51,7 @@ func TestConstructListObjInput(t *testing.T) {
 			expected: s3.ListObjectsV2Input{
 				Bucket:            aws.String("myBucket"),
 				Delimiter:         aws.String("/"),
-				Prefix:            aws.String("/mypath"),
+				Prefix:            aws.String("mypath/"),
 				MaxKeys:           aws.Int64(20),
 				ContinuationToken: aws.String("FOO"),
 			},


### PR DESCRIPTION
Fix for issue #53 that I opened. Swaps the `TrimSuffix` function on the browse directory path to a `TrimPrefix` in order for browse functionality to work properly.