### PR TITLE
fixes 403 on cached fetch to index files

### DIFF
--- a/s3proxy.go
+++ b/s3proxy.go
@@ -446,7 +446,8 @@ func (p S3Proxy) GetHandler(w http.ResponseWriter, r *http.Request, fullPath str
 		for _, indexPage := range p.IndexNames {
 			indexPath := path.Join(fullPath, indexPage)
 			obj, err = p.getS3Object(p.Bucket, indexPath, r.Header)
-			if err == nil {
+			caddyErr := convertToCaddyError(err)
+			if err == nil || caddyErr.StatusCode == 304 {
 				// We found an index!
 				isDir = false
 				break
@@ -487,7 +488,7 @@ func (p S3Proxy) GetHandler(w http.ResponseWriter, r *http.Request, fullPath str
 	if err != nil {
 		caddyErr := convertToCaddyError(err)
 		if caddyErr.StatusCode == http.StatusNotFound {
-			// Log as debug as this one may be qute common
+			// Log as debug as this one may be quite common
 			p.log.Debug("not found",
 				zap.String("bucket", p.Bucket),
 				zap.String("key", fullPath),

--- a/s3proxy_test.go
+++ b/s3proxy_test.go
@@ -321,6 +321,17 @@ func TestProxy(t *testing.T) {
 			expectedResponseText: "my index.html",
 		},
 		{
+			name:   "returns 304 If-None-Match on index",
+			proxy:  S3Proxy{Bucket: bucketName, IndexNames: []string{"index.html"}},
+			method: http.MethodGet,
+			path:   "/inner/",
+			headers: http.Header{
+				"If-None-Match": []string{`"44bacca965de5aef310706cc55c4a7b0"`},
+			},
+			expectedCode:         http.StatusNotModified,
+			expectsEmptyResponse: true,
+		},
+		{
 			name:                 "cannot browse",
 			proxy:                S3Proxy{Bucket: bucketName},
 			method:               http.MethodGet,


### PR DESCRIPTION
Fixes [#56]

- Added tests that fetches the index.html with cache headers. 
- fixed typo in comments
- using 'caddy error' to determine if it's a 'not-modified' response