### PR TITLE
Write (deferred) headers

### DIFF
--- a/s3proxy.go
+++ b/s3proxy.go
@@ -332,6 +332,7 @@ func (p S3Proxy) writeResponseFromGetObject(w http.ResponseWriter, obj *s3.GetOb
 	if obj.Body != nil {
 		// io.Copy will set Content-Length
 		w.Header().Del("Content-Length")
+		w.WriteHeader(http.StatusOK)
 		_, err = io.Copy(w, obj.Body)
 	}
 


### PR DESCRIPTION
Unlike `ResponseWriter.Write`, `io.Copy` doesn't add the deferred headers. Deferred headers are applied _after_ the proxied response.

This (not standalong) is CORS configuration, for example, that only works with the change.

```Caddyfile
header {
  Access-Control-Allow-Origin "{re.origin.0}"
  Access-Control-Allow-Credentials true
  Access-Control-Expose-Headers "{args[1]}"
  Vary Origin
  defer
}
```

Fixes #65 (though I suppose there may be issues with PUT and DELETE, too).

(Edit: PUT and, probably, DELETE, are affected, too — this can be merged as is, but if I fix PUT and DELETE beforehand I'll add to this PR.)