### PR TITLE
Close GetObject bodies to avoid leaking memory

### DIFF
--- a/s3proxy.go
+++ b/s3proxy.go
@@ -343,6 +343,7 @@ func (p S3Proxy) serveErrorPage(w http.ResponseWriter, s3Key string) error {
 	if err != nil {
 		return err
 	}
+	defer obj.Body.Close()
 
 	if err := p.writeResponseFromGetObject(w, obj); err != nil {
 		return err
@@ -448,6 +449,8 @@ func (p S3Proxy) GetHandler(w http.ResponseWriter, r *http.Request, fullPath str
 			obj, err = p.getS3Object(p.Bucket, indexPath, r.Header)
 			caddyErr := convertToCaddyError(err)
 			if err == nil || caddyErr.StatusCode == 304 {
+				defer obj.Body.Close()
+
 				// We found an index!
 				isDir = false
 				break
@@ -504,6 +507,7 @@ func (p S3Proxy) GetHandler(w http.ResponseWriter, r *http.Request, fullPath str
 
 		return caddyErr
 	}
+	defer obj.Body.Close()
 
 	return p.writeResponseFromGetObject(w, obj)
 }


### PR DESCRIPTION
Calls to the `GetObject` method of the S3 client require that the `Body` be closed to avoid leaking memory. The returned struct is an `http.Response` returned by an `http.Client` (verified by digging into the AWS SDK dependency chain) and is guaranteed to always have a non-nil `Body`.

The only way I've been able to spot this issue is in prod after a few days of load. I'm testing this patch now and it already appears to be holding Caddy memory usage much more steady.

Related to and should fix #64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved resource management in the S3Proxy class to prevent potential resource leaks by ensuring response bodies are properly closed after use.
- **New Features**
	- Enhanced stability and performance of the application when handling multiple S3 object requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->